### PR TITLE
Adhere Inpsyde PHP Coding Standards

### DIFF
--- a/Inpsyde/PHPCSAliases.php
+++ b/Inpsyde/PHPCSAliases.php
@@ -1,4 +1,6 @@
-<?php
+<?php declare(strict_types=1);
+// phpcs:disable PSR1.Files.SideEffects
+
 /**
  * This file contains code from "WordPress-Coding-Standards" project
  * found at https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
@@ -39,20 +41,28 @@ if (!defined('WPCS_PHPCS_ALIASES_SET')) {
 
     // PHPCS classes which are being extended by WPCS sniffs.
     if (!class_exists('\PHP_CodeSniffer_Standards_AbstractVariableSniff')) {
-        class_alias('PHP_CodeSniffer\Sniffs\AbstractVariableSniff',
-            '\PHP_CodeSniffer_Standards_AbstractVariableSniff');
+        class_alias(
+            'PHP_CodeSniffer\Sniffs\AbstractVariableSniff',
+            '\PHP_CodeSniffer_Standards_AbstractVariableSniff'
+        );
     }
     if (!class_exists('\PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff')) {
-        class_alias('PHP_CodeSniffer\Standards\PEAR\Sniffs\NamingConventions\ValidFunctionNameSniff',
-            '\PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff');
+        class_alias(
+            'PHP_CodeSniffer\Standards\PEAR\Sniffs\NamingConventions\ValidFunctionNameSniff',
+            '\PEAR_Sniffs_NamingConventions_ValidFunctionNameSniff'
+        );
     }
     if (!class_exists('\Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff')) {
-        class_alias('PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\OperatorSpacingSniff',
-            '\Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff');
+        class_alias(
+            'PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\OperatorSpacingSniff',
+            '\Squiz_Sniffs_WhiteSpace_OperatorSpacingSniff'
+        );
     }
     if (!class_exists('\Squiz_Sniffs_WhiteSpace_SemicolonSpacingSniff')) {
-        class_alias('PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\SemicolonSpacingSniff',
-            '\Squiz_Sniffs_WhiteSpace_SemicolonSpacingSniff');
+        class_alias(
+            'PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\SemicolonSpacingSniff',
+            '\Squiz_Sniffs_WhiteSpace_SemicolonSpacingSniff'
+        );
     }
 
     define('WPCS_PHPCS_ALIASES_SET', true);
@@ -74,13 +84,18 @@ if (!defined('WPCS_PHPCS_ALIASES_SET')) {
         }
 
         // PHPCS handles the Test and Sniff classes without problem.
-        if (stripos($class, '\Tests\\') !== false || stripos($class,
-                '\Sniffs\\') !== false) {
+        if (stripos($class, '\Tests\\') !== false || stripos(
+            $class,
+            '\Sniffs\\'
+        ) !== false) {
             return;
         }
 
-        $file = dirname(__DIR__) . DIRECTORY_SEPARATOR . strtr($class, '\\',
-                DIRECTORY_SEPARATOR) . '.php';
+        $file = dirname(__DIR__) . DIRECTORY_SEPARATOR . strtr(
+            $class,
+            '\\',
+            DIRECTORY_SEPARATOR
+        ) . '.php';
 
         if (file_exists($file)) {
             include_once $file;

--- a/Inpsyde/PhpcsHelpers.php
+++ b/Inpsyde/PhpcsHelpers.php
@@ -117,7 +117,7 @@ class PhpcsHelpers
      * @param int $position
      * @return bool
      */
-    public static function functionIsMethod(File $file, int $position)
+    public static function functionIsMethod(File $file, int $position): bool
     {
         $tokens = $file->getTokens();
         $functionToken = $tokens[$position];
@@ -151,7 +151,7 @@ class PhpcsHelpers
      * @param int $position
      * @return bool
      */
-    public static function functionIsArrayAccess(File $file, int $position)
+    public static function functionIsArrayAccess(File $file, int $position): bool
     {
         $token = $file->getTokens()[$position] ?? null;
         if (!$token || $token['code'] !== T_FUNCTION || !self::functionIsMethod($file, $position)) {
@@ -183,6 +183,7 @@ class PhpcsHelpers
     {
         $tokens = $file->getTokens();
         $code = $tokens[$position]['code'] ?? -1;
+
         if (!in_array($code, [T_VARIABLE, T_STRING], true)) {
             return false;
         }
@@ -288,7 +289,7 @@ class PhpcsHelpers
      * @param int $start
      * @param int $end
      * @param File $file
-     * @param array ...$types
+     * @param string[] ...$types
      * @return array[]
      */
     public static function filterTokensByType(
@@ -482,8 +483,12 @@ class PhpcsHelpers
      * @param bool $includeNull
      * @return bool
      */
-    public static function isVoidReturn(File $file, int $returnPosition, $includeNull = false): bool
-    {
+    public static function isVoidReturn(
+        File $file,
+        int $returnPosition,
+        bool $includeNull = false
+    ): bool {
+
         $tokens = $file->getTokens();
 
         if (($tokens[$returnPosition]['code'] ?? '') !== T_RETURN) {
@@ -550,7 +555,6 @@ class PhpcsHelpers
         $end = $lastBeforeFunc - 1;
 
         for ($i = $start; $i < $end; $i++) {
-
             if ($inTag && $tokens[$i]['code'] === T_DOC_COMMENT_STRING) {
                 $tags[] .= $tokens[$i]['content'];
                 continue;

--- a/Inpsyde/Sniffs/CodeQuality/ArgumentTypeDeclarationSniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/ArgumentTypeDeclarationSniff.php
@@ -36,7 +36,7 @@ class ArgumentTypeDeclarationSniff implements Sniff
     /**
      * @inheritdoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_FUNCTION, T_CLOSURE];
     }

--- a/Inpsyde/Sniffs/CodeQuality/AssignmentInsideConditionSniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/AssignmentInsideConditionSniff.php
@@ -24,7 +24,7 @@ final class AssignmentInsideConditionSniff implements Sniff
     /**
      * @return int[]
      */
-    public function register()
+    public function register(): array
     {
         return [T_IF, T_ELSEIF];
     }
@@ -102,7 +102,8 @@ final class AssignmentInsideConditionSniff implements Sniff
         int $insideIfAssignmentPosition,
         int $ifOpenerPosition,
         File $file
-    ) {
+    ): bool {
+
         $insideIfOpenParenthesisPosition = $file->findPrevious(
             T_OPEN_PARENTHESIS,
             $insideIfAssignmentPosition - 1,

--- a/Inpsyde/Sniffs/CodeQuality/DisallowShortOpenTagSniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/DisallowShortOpenTagSniff.php
@@ -21,7 +21,7 @@ final class DisallowShortOpenTagSniff extends Generic\DisallowShortOpenTagSniff
     /**
      * @return int[]
      */
-    public function register()
+    public function register(): array
     {
         return [
             T_OPEN_TAG,

--- a/Inpsyde/Sniffs/CodeQuality/ElementNameMinimalLengthSniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/ElementNameMinimalLengthSniff.php
@@ -51,7 +51,7 @@ final class ElementNameMinimalLengthSniff implements Sniff
     /**
      * @return int[]
      */
-    public function register()
+    public function register(): array
     {
         return [T_CLASS, T_TRAIT, T_INTERFACE, T_CONST, T_FUNCTION, T_VARIABLE];
     }
@@ -90,6 +90,7 @@ final class ElementNameMinimalLengthSniff implements Sniff
         int $elementNameLength,
         string $elementName
     ): bool {
+
         if ($elementNameLength >= $this->minLength) {
             return true;
         }

--- a/Inpsyde/Sniffs/CodeQuality/ForbiddenPublicPropertySniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/ForbiddenPublicPropertySniff.php
@@ -29,7 +29,7 @@ final class ForbiddenPublicPropertySniff implements Sniff
     /**
      * @return int[]
      */
-    public function register()
+    public function register(): array
     {
         return [T_VARIABLE];
     }

--- a/Inpsyde/Sniffs/CodeQuality/FunctionBodyStartSniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/FunctionBodyStartSniff.php
@@ -19,7 +19,7 @@ class FunctionBodyStartSniff implements Sniff
     /**
      * @return int[]
      */
-    public function register()
+    public function register(): array
     {
         return [T_FUNCTION];
     }
@@ -105,7 +105,7 @@ class FunctionBodyStartSniff implements Sniff
             return [
                 $code,
                 "In functions {$where}, function body should start with a blank line.",
-                $openerLine + 2
+                $openerLine + 2,
             ];
         }
 
@@ -119,7 +119,7 @@ class FunctionBodyStartSniff implements Sniff
         return [
             'WrongForSingleLineDeclaration',
             $message,
-            $openerLine + 1
+            $openerLine + 1,
         ];
     }
 

--- a/Inpsyde/Sniffs/CodeQuality/FunctionLengthSniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/FunctionLengthSniff.php
@@ -47,7 +47,7 @@ final class FunctionLengthSniff implements Sniff
     /**
      * @return int[]
      */
-    public function register()
+    public function register(): array
     {
         return [T_FUNCTION];
     }
@@ -185,6 +185,7 @@ final class FunctionLengthSniff implements Sniff
         int $position,
         array $docBlocks
     ): array {
+
         if (!$this->ignoreDocBlocks
             || $tokens[$position]['code'] !== T_DOC_COMMENT_OPEN_TAG
         ) {

--- a/Inpsyde/Sniffs/CodeQuality/HookClosureReturnSniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/HookClosureReturnSniff.php
@@ -19,7 +19,7 @@ class HookClosureReturnSniff implements Sniff
     /**
      * @inheritdoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_CLOSURE];
     }

--- a/Inpsyde/Sniffs/CodeQuality/LineLengthSniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/LineLengthSniff.php
@@ -72,7 +72,7 @@ class LineLengthSniff implements Sniff
     /**
      * @inheritdoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_OPEN_TAG];
     }
@@ -80,7 +80,7 @@ class LineLengthSniff implements Sniff
     /**
      * @inheritdoc
      */
-    public function process(File $file, $position)
+    public function process(File $file, $position): int
     {
         $longLinesData = $this->collectLongLinesData($file, max(1, $position));
         if (!$longLinesData) {

--- a/Inpsyde/Sniffs/CodeQuality/NoAccessorsSniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/NoAccessorsSniff.php
@@ -40,7 +40,7 @@ final class NoAccessorsSniff implements Sniff
     /**
      * @return int[]
      */
-    public function register()
+    public function register(): array
     {
         return [T_FUNCTION];
     }

--- a/Inpsyde/Sniffs/CodeQuality/NoElseSniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/NoElseSniff.php
@@ -27,7 +27,7 @@ final class NoElseSniff implements Sniff
     /**
      * @return int[]
      */
-    public function register()
+    public function register(): array
     {
         return [T_ELSE];
     }

--- a/Inpsyde/Sniffs/CodeQuality/NoTopLevelDefineSniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/NoTopLevelDefineSniff.php
@@ -23,7 +23,7 @@ final class NoTopLevelDefineSniff implements Sniff
     /**
      * @return int[]
      */
-    public function register()
+    public function register(): array
     {
         return [T_STRING];
     }

--- a/Inpsyde/Sniffs/CodeQuality/PropertyPerClassLimitSniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/PropertyPerClassLimitSniff.php
@@ -33,7 +33,7 @@ final class PropertyPerClassLimitSniff implements Sniff
     /**
      * @return int[]
      */
-    public function register()
+    public function register(): array
     {
         return [T_CLASS, T_TRAIT];
     }

--- a/Inpsyde/Sniffs/CodeQuality/Psr4Sniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/Psr4Sniff.php
@@ -33,7 +33,7 @@ final class Psr4Sniff implements Sniff
     /**
      * @return int[]
      */
-    public function register()
+    public function register(): array
     {
         return [T_CLASS, T_INTERFACE, T_TRAIT];
     }

--- a/Inpsyde/Sniffs/CodeQuality/ReturnTypeDeclarationSniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/ReturnTypeDeclarationSniff.php
@@ -45,7 +45,7 @@ class ReturnTypeDeclarationSniff implements Sniff
     /**
      * @inheritdoc
      */
-    public function register()
+    public function register(): array
     {
         return [T_FUNCTION, T_CLOSURE];
     }


### PR DESCRIPTION
@gmazzap 

```
$ vendor/bin/phpcs --standard=Inpsyde Inpsyde/ --exclude=Inpsyde.CodeQuality.ArgumentTypeDeclaration

---------------------------------------------------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
---------------------------------------------------------------------------------------------------------------------------------------
 182 | ERROR | Your function is too long. Currently using 52 lines (ignoring blank lines, single line comments and doc blocks), max is
     |       | 50. (Inpsyde.CodeQuality.FunctionLength.TooLong)
---------------------------------------------------------------------------------------------------------------------------------------
```

I am not able to resolve this one.

The cause of `Inpsyde.CodeQuality.ArgumentTypeDeclaration` is PHPCS! Maybe I am wrong on this.
