### PR TITLE
upgrades dealerdirect/phpcodesniffer-composer-installer to ^0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   "require": {
     "php": ">=7.0",
     "squizlabs/php_codesniffer": "^3",
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.4",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
     "wp-coding-standards/wpcs": "^0.14",
     "automattic/phpcs-neutron-standard": "^1",
     "phpcompatibility/php-compatibility": "^9.0"


### PR DESCRIPTION
`ProcessBuilder` class have been deprecated on `symfony/process` 3.4.0 so the ^0.5 release of `dealerdirect/phpcodesniffer-composer-installer` replaces it with `Composer\Util\ProcessExecutor`

See:
- https://github.com/symfony/process/blob/master/CHANGELOG.md\#340
- https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases/tag/v0.5.0
- https://github.com/Dealerdirect/phpcodesniffer-composer-installer/pull/70