### PR TITLE
Allow blank line after single line declaration #32

### DIFF
--- a/Inpsyde/Sniffs/CodeQuality/FunctionBodyStartSniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/FunctionBodyStartSniff.php
@@ -86,7 +86,7 @@ class FunctionBodyStartSniff implements Sniff
 
         $error =
             ($isMultiLineDeclare || $isSingleLineSignature) && $bodyLine !== ($openerLine + 2)
-            || $isSingleLineDeclare && $bodyLine !== ($openerLine + 1);
+            || $isSingleLineDeclare && $bodyLine > ($openerLine + 2);
 
         if (!$error) {
             return [null, null, null];

--- a/tests/fixtures/function-body-start.php
+++ b/tests/fixtures/function-body-start.php
@@ -8,7 +8,8 @@ function foo()
     return 'foo';
 }
 
-// @phpcsWarningCodeOnNextLine WrongForSingleLineDeclaration
+// tolerate this as PHPStorm code styler cannot distinguish between
+// single line and multiline function declarations. See issue #32
 function bar()
 {
 
@@ -66,7 +67,6 @@ class BarBarBar
         return 'foo';
     }
 
-    // @phpcsWarningCodeOnNextLine WrongForSingleLineDeclaration
     private function bar()
     {
 

--- a/tests/fixtures/function-body-start.php
+++ b/tests/fixtures/function-body-start.php
@@ -16,6 +16,13 @@ function bar()
     return 'bar';
 }
 
+// @phpcsWarningCodeOnNextLine WrongForSingleLineSignature
+function lorem() {
+
+
+    return 'ipsum';
+}
+
 // @phpcsWarningCodeOnNextLine WrongForMultiLineDeclaration
 function fooFoo(
     string $foo,
@@ -71,6 +78,13 @@ class BarBarBar
     {
 
         return 'bar';
+    }
+
+    // @phpcsWarningCodeOnNextLine WrongForSingleLineSignature
+    public function lorem() {
+
+
+        return 'ipsum';
     }
 
     // @phpcsWarningCodeOnNextLine WrongForMultiLineDeclaration


### PR DESCRIPTION
The sniff allows now zero or one blank line after a single line declaration. Also added another test to make sure not more then one blank line are allowed. 