### PR TITLE
Remove "skip ci" check from GitHub Actions workflow file

### DIFF
--- a/.github/workflows/php-qa.yml
+++ b/.github/workflows/php-qa.yml
@@ -4,8 +4,6 @@ jobs:
 
     Unit_Tests:
         runs-on: ubuntu-latest
-        if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
-
         strategy:
             matrix:
                 php: ['7.0', '7.1', '7.2', '7.3', '7.4']
@@ -54,8 +52,6 @@ jobs:
 
     Static_Analisys:
       runs-on: ubuntu-latest
-      if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
-
       steps:
         - uses: actions/checkout@v2
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Improvement


**What is the current behavior?** (You can also link to an open issue here)
The Quality Assurance GitHub Actions workflow file contains logic for skipping the jobs if the commit message contains the words `ci skip`.


**What is the new behavior (if this is a feature change)?**
The Quality Assurance GitHub Actions workflow file does not contain logic for skipping the jobs if the commit message contains the words `ci skip`.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**:
The mentioned logic is no longer necessary because GitHub Actions provides its own logic that even listens to more keywords. For details, see https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/.