### PR TITLE
Update Composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=7",
-        "squizlabs/php_codesniffer": "~3.5.6",
+        "squizlabs/php_codesniffer": "~3.6.0",
         "dealerdirect/phpcodesniffer-composer-installer": "~0.7.0",
         "wp-coding-standards/wpcs": "^2.3",
         "automattic/vipwpcs": "^2.2",
@@ -37,7 +37,7 @@
         "automattic/phpcs-neutron-standard": "^1.6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "6.5.* || 9.4.*",
+        "phpunit/phpunit": "~6.5.0 || ~9.5.0",
         "vimeo/psalm": "@stable"
     },
     "autoload-dev": {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Improvement


**What is the current behavior?** (You can also link to an open issue here)
Composer dependencies are outdated:
```
% composer outdated -D
phpunit/phpunit           9.4.4 9.5.5 The PHP Unit Testing framework.
squizlabs/php_codesniffer 3.5.8 3.6.0 PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.
```

**What is the new behavior (if this is a feature change)?**
Composer dependencies have been updated. 


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.


**Other information**:
Tests still pass. Also, PHPUnit version constraints have been changed from X-Range to tilde constraint (e.g. `9.4.*` to `~9.5.0`). This has no effect on the set of installable versions but aligns the constraint with the tilde constraints used in the `"require"` property.

To automate PRs like this in the future, it might make sense to add a `dependabot.yml` file, see https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates.