### PR TITLE
Add check for Emacs UTF-8 file header

### DIFF
--- a/Inpsyde/Sniffs/CodeQuality/EncodingCommentSniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/EncodingCommentSniff.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the "php-coding-standards" package.
+ *
+ * Copyright (c) 2023 Inpsyde GmbH
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+declare(strict_types=1);
+
+namespace Inpsyde\Sniffs\CodeQuality;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHPCSUtils\Utils\PassedParameters;
+
+class EncodingCommentSniff implements Sniff
+{
+    private const DISALLOWED_COMMENT = '-*- coding: utf-8 -*-';
+
+    /**
+     * @return list<int>
+     */
+    public function register(): array
+    {
+        return [T_COMMENT];
+    }
+
+    /**
+     * @param File $phpcsFile
+     * @param int $stackPtr
+     * @return void
+     *
+     * phpcs:disable Inpsyde.CodeQuality.ArgumentTypeDeclaration
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        // phpcs:enable Inpsyde.CodeQuality.ArgumentTypeDeclaration
+
+        $tokens = $phpcsFile->getTokens();
+
+        $comment = isset($tokens[$stackPtr]['content']) && is_string($tokens[$stackPtr]['content'])
+            ? $tokens[$stackPtr]['content']
+            : '';
+
+        if (strpos($comment, self::DISALLOWED_COMMENT) === false) {
+            return;
+        }
+
+        $fix = $phpcsFile->addFixableWarning(
+            'Found outdated encoding declaration in comment.',
+            $stackPtr,
+            'EncodingComment'
+        );
+
+        if ($fix) {
+            $this->fix($phpcsFile, $stackPtr);
+        }
+    }
+
+    private function fix(File $phpcsFile, int $position): void
+    {
+        $phpcsFile->fixer->beginChangeset();
+
+        $phpcsFile->fixer->replaceToken($position, '');
+
+        $phpcsFile->fixer->endChangeset();
+    }
+}

--- a/inpsyde-custom-sniffs.md
+++ b/inpsyde-custom-sniffs.md
@@ -6,10 +6,12 @@
 - Inpsyde.CodeQuality.ConstantVisibility
 - Inpsyde.CodeQuality.DisallowShortOpenTag
 - Inpsyde.CodeQuality.ElementNameMinimalLength
+- Inpsyde.CodeQuality.EncodingComment
 - Inpsyde.CodeQuality.ForbiddenPublicProperty
 - Inpsyde.CodeQuality.FunctionBodyStart
 - Inpsyde.CodeQuality.FunctionLength
 - Inpsyde.CodeQuality.HookClosureReturn
+- Inpsyde.CodeQuality.HookPriority
 - Inpsyde.CodeQuality.LineLength
 - Inpsyde.CodeQuality.NestingLevel
 - Inpsyde.CodeQuality.NoAccessors
@@ -94,6 +96,15 @@ alternatively, whitelist can be extended via `additionalAllowedNames` config, e.
     </properties>
 </rule>
 ```
+
+-----
+## Inpsyde.CodeQuality.EncodingComment
+
+Prevent usage of some outdated encoding definition in PHP comments.
+
+It raises a Warning if something like this is found `-*- coding: utf-8 -*-`.
+
+This sniff has no available configuration.
 
 -----
 

--- a/inpsyde-custom-sniffs.md
+++ b/inpsyde-custom-sniffs.md
@@ -11,7 +11,6 @@
 - Inpsyde.CodeQuality.FunctionBodyStart
 - Inpsyde.CodeQuality.FunctionLength
 - Inpsyde.CodeQuality.HookClosureReturn
-- Inpsyde.CodeQuality.HookPriority
 - Inpsyde.CodeQuality.LineLength
 - Inpsyde.CodeQuality.NestingLevel
 - Inpsyde.CodeQuality.NoAccessors

--- a/tests/fixtures/encoding-comment.php
+++ b/tests/fixtures/encoding-comment.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Inpsyde\CodingStandard\Tests\Fixtures;
+
+
+// @phpcsSniff CodeQuality.EncodingComment
+
+// @phpcsWarningCodeOnNextLine EncodingComment
+// -*- coding: utf-8 -*-
+?>
+
+<?php # -*- coding: utf-8 -*-
+// @phpcsWarningOnPreviousLine CodeQuality.EncodingComment
+?>
+
+<?php //-*- coding: utf-8 -*-
+// @phpcsWarningOnPreviousLine CodeQuality.EncodingComment
+?>


### PR DESCRIPTION
This actually prevents the usage of that declaration in every comment, not only on the same line of PHP tag opening.

**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes/features)
- [X] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?**
New Feature


**What is the current behavior?**
The declaration can be used `-*- coding: utf-8 -*-` everywhere without any prevention.


**What is the new behavior?**
The new custom sniff raises a warning if the declaration `-*- coding: utf-8 -*-` is found in a comment.

Note: Since the declaration would be removed from the first line anyway by `PSR12.Files.OpenTag.NotAlone`, this new sniff actually search for it in every comment in the file.

If found, `phpcbf` will get rid of **the whole comment line**. I think it is safe enough to assume that there won't be anything else in the same comment.


**Does this PR introduce a breaking change?**
No


**Other information**:
As usual, any suggestion to improve the sniff name or the error message are more than welcome 👂 