### PR TITLE
PHP templates-specific sniffs

### DIFF
--- a/Inpsyde/Helpers/FunctionDocBlock.php
+++ b/Inpsyde/Helpers/FunctionDocBlock.php
@@ -170,11 +170,10 @@ final class FunctionDocBlock
             if (strpos($splitType, '&') !== false) {
                 $splitType = rtrim(ltrim($splitType, '('), ')');
             } elseif (strpos($splitType, '?') === 0) {
-                $splitType = substr($splitType, 1);
-                $hasNull = $hasNull || (($splitType !== '') && ($splitType !== false));
+                $splitType = (string) substr($splitType, 1);
+                $hasNull = $hasNull || ($splitType !== '');
             }
-            /** @psalm-suppress DocblockTypeContradiction */
-            if (($splitType === false) || ($splitType === '')) {
+            if ($splitType === '') {
                 continue;
             }
             if (strtolower($splitType) === 'null') {

--- a/InpsydeTemplates/Sniffs/Formatting/TrailingSemicolonSniff.php
+++ b/InpsydeTemplates/Sniffs/Formatting/TrailingSemicolonSniff.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the "php-coding-standards" package.
+ *
+ * Copyright (c) 2023 Inpsyde GmbH
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+declare(strict_types=1);
+
+namespace InpsydeTemplates\Sniffs\Formatting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * @psalm-type Token = array{
+ *     type: string,
+ *     code: string|int,
+ *     line: int
+ *     }
+ */
+final class TrailingSemicolonSniff implements Sniff
+{
+    /**
+     * @return list<int|string>
+     */
+    public function register(): array
+    {
+        return [
+            T_SEMICOLON,
+        ];
+    }
+
+    /**
+     * @param File $phpcsFile
+     * @param int $stackPtr
+     *
+     * phpcs:disable Inpsyde.CodeQuality.ArgumentTypeDeclaration
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        // phpcs:enable Inpsyde.CodeQuality.ArgumentTypeDeclaration
+
+        /** @var array<int, Token> $tokens */
+        $tokens = $phpcsFile->getTokens();
+        $currentLine = $tokens[$stackPtr]['line'];
+
+        $nextNonEmptyPosition = $phpcsFile->findNext(
+            Tokens::$emptyTokens,
+            ($stackPtr + 1),
+            null,
+            true
+        );
+
+        if (!is_int($nextNonEmptyPosition) || !isset($tokens[$nextNonEmptyPosition])) {
+            return;
+        }
+
+        $nextNonEmptyToken = $tokens[$nextNonEmptyPosition];
+
+        if ($nextNonEmptyToken['line'] !== $currentLine) {
+            return;
+        }
+
+        if ($nextNonEmptyToken['code'] !== T_CLOSE_TAG) {
+            return;
+        }
+
+        $message = sprintf('Trailing semicolon found at line %d.', $currentLine);
+
+        if ($phpcsFile->addFixableWarning($message, $stackPtr, 'Found')) {
+            $this->fix($stackPtr, $phpcsFile);
+        }
+    }
+
+    /**
+     * @param int $position
+     * @param File $file
+     */
+    private function fix(int $position, File $file): void
+    {
+        $fixer = $file->fixer;
+        $fixer->beginChangeset();
+
+        $fixer->replaceToken($position, '');
+
+        $fixer->endChangeset();
+    }
+}

--- a/InpsydeTemplates/Sniffs/Formatting/TrailingSemicolonSniff.php
+++ b/InpsydeTemplates/Sniffs/Formatting/TrailingSemicolonSniff.php
@@ -86,7 +86,7 @@ final class TrailingSemicolonSniff implements Sniff
             return;
         }
 
-        $message = sprintf('Trailing semicolon found at line %d.', $currentLine);
+        $message = sprintf('Trailing semicolon found in line %d.', $currentLine);
 
         if ($phpcsFile->addFixableWarning($message, $stackPtr, 'Found')) {
             $this->fix($stackPtr, $phpcsFile);

--- a/InpsydeTemplates/ruleset.xml
+++ b/InpsydeTemplates/ruleset.xml
@@ -3,4 +3,8 @@
 
     <description>Coding standards for PHP templates.</description>
 
+    <rule ref="Inpsyde">
+        <exclude name="Inpsyde.CodeQuality.NoElse" />
+    </rule>
+
 </ruleset>

--- a/InpsydeTemplates/ruleset.xml
+++ b/InpsydeTemplates/ruleset.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<ruleset name="Inpsyde PHP Templates Coding Standard">
+
+    <description>Coding standards for PHP templates.</description>
+
+</ruleset>

--- a/README.md
+++ b/README.md
@@ -182,12 +182,12 @@ For **notes and configuration** see [`/inpsyde-custom-sniffs.md`](/inpsyde-custo
 
 -------------
 
-## Templates Rules
+## Template Rules
 
-InpsydeTemplates ruleset extends Inpsyde ruleset apart from several rules that doesn't make sense in
-the templating context. Several template-specific sniffs are added.
+The `InpsydeTemplates` ruleset extends the standard `Inpsyde` ruleset with some template-specific
+sniffs while disabling some rules that are not useful in templating context.
 
-The recommended way of using InpsydeTemplates ruleset:
+The recommended way to use the `InpsydeTemplates` ruleset is as follows:
 
 ```xml
 <ruleset>
@@ -208,13 +208,13 @@ The recommended way of using InpsydeTemplates ruleset:
 </ruleset>
 ```
 The following Inpsyde rules are disabled:
-* NoElse
+* `NoElse`
 
 The following templates-specific rules are available:
 
-| Sniff name          | Description                                     | Has Config | Auto-Fixable |
-|:--------------------|:------------------------------------------------|:----------:|:------------:|
-| `TrailingSemicolon` | Remove trailing semicolon before close PHP tag. |            |      ✓       |
+| Sniff name          | Description                                       | Has Config | Auto-Fixable |
+|:--------------------|:--------------------------------------------------|:----------:|:------------:|
+| `TrailingSemicolon` | Remove trailing semicolon before closing PHP tag. |            |      ✓       |
 
 # Removing or Disabling Rules
 

--- a/README.md
+++ b/README.md
@@ -184,15 +184,31 @@ For **notes and configuration** see [`/inpsyde-custom-sniffs.md`](/inpsyde-custo
 
 ## Templates Rules
 
-InpsydeTemplates ruleset contains custom rules targeted to the PHP templates and views.
-To enable the ruleset only for templates the following configuration could be used:
+InpsydeTemplates ruleset extends Inpsyde ruleset apart from several rules that doesn't make sense in
+the templating context. Several template-specific sniffs are added.
+
+The recommended way of using InpsydeTemplates ruleset:
 
 ```xml
-<rule ref="InpsydeTemplates">
-    <include-pattern>*/templates/*</include-pattern>
-    <include-pattern>*/views/*</include-pattern>
-</rule>
+<ruleset>
+    <file>./src/</file>
+    <file>./tests</file>
+    <file>./templates</file>
+    <file>./block-views</file>
+
+    <rule ref="Inpsyde">
+        <exclude-pattern>*/templates/*</exclude-pattern>
+        <exclude-pattern>*/views/*</exclude-pattern>
+    </rule>
+
+    <rule ref="InpsydeTemplates">
+        <include-pattern>*/templates/*</include-pattern>
+        <include-pattern>*/views/*</include-pattern>
+    </rule>
+</ruleset>
 ```
+The following Inpsyde rules are disabled:
+* NoElse
 
 The following templates-specific rules are available:
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ The recommended way to use the `InpsydeTemplates` ruleset is as follows:
     <file>./src/</file>
     <file>./tests</file>
     <file>./templates</file>
-    <file>./block-views</file>
+    <file>./views</file>
 
     <rule ref="Inpsyde">
         <exclude-pattern>*/templates/*</exclude-pattern>
@@ -207,7 +207,7 @@ The recommended way to use the `InpsydeTemplates` ruleset is as follows:
     </rule>
 </ruleset>
 ```
-The following Inpsyde rules are disabled:
+The following `Inpsyde` rules are disabled:
 * `NoElse`
 
 The following templates-specific rules are available:

--- a/README.md
+++ b/README.md
@@ -182,6 +182,24 @@ For **notes and configuration** see [`/inpsyde-custom-sniffs.md`](/inpsyde-custo
 
 -------------
 
+## Templates Rules
+
+InpsydeTemplates ruleset contains custom rules targeted to the PHP templates and views.
+To enable the ruleset only for templates the following configuration could be used:
+
+```xml
+<rule ref="InpsydeTemplates">
+    <include-pattern>*/templates/*</include-pattern>
+    <include-pattern>*/views/*</include-pattern>
+</rule>
+```
+
+The following templates-specific rules are available:
+
+| Sniff name          | Description                                     | Has Config | Auto-Fixable |
+|:--------------------|:------------------------------------------------|:----------:|:------------:|
+| `TrailingSemicolon` | Remove trailing semicolon before close PHP tag. |            |      ✓       |
+
 # Removing or Disabling Rules
 
 ## Rules Tree

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -35,7 +35,7 @@ if (!is_file($autoload)) {
     die('Please install via Composer before running tests.');
 }
 
-putenv("SNIFFS_PATH={$libDir}/Inpsyde/Sniffs");
+putenv("LIB_PATH={$libDir}");
 putenv('SNIFFS_NAMESPACE=Inpsyde\\Sniffs');
 putenv("FIXTURES_PATH={$testsDir}/fixtures");
 

--- a/tests/fixtures/Psr4Fixture.php
+++ b/tests/fixtures/Psr4Fixture.php
@@ -1,5 +1,5 @@
 <?php # -*- coding: utf-8 -*-
-// @phpcsSniff CodeQuality.Psr4
+// @phpcsSniff Inpsyde.CodeQuality.Psr4
 
 namespace {
 

--- a/tests/fixtures/argument-type-declaration.php
+++ b/tests/fixtures/argument-type-declaration.php
@@ -1,5 +1,5 @@
 <?php
-// @phpcsSniff CodeQuality.ArgumentTypeDeclaration
+// @phpcsSniff Inpsyde.CodeQuality.ArgumentTypeDeclaration
 
 use Psr\Container as PsrContainer;
 

--- a/tests/fixtures/disable-call-user-func.php
+++ b/tests/fixtures/disable-call-user-func.php
@@ -1,5 +1,5 @@
 <?php
-// @phpcsSniff CodeQuality.DisableCallUserFunc
+// @phpcsSniff Inpsyde.CodeQuality.DisableCallUserFunc
 
 function test() {
     // @phpcsErrorOnNextLine

--- a/tests/fixtures/disallow-magic-serialize.php
+++ b/tests/fixtures/disallow-magic-serialize.php
@@ -1,6 +1,6 @@
 <?php
 
-// @phpcsSniff CodeQuality.DisableMagicSerialize
+// @phpcsSniff Inpsyde.CodeQuality.DisableMagicSerialize
 
 class Foo {
 

--- a/tests/fixtures/disallow-short-open-tag.php
+++ b/tests/fixtures/disallow-short-open-tag.php
@@ -13,7 +13,7 @@ function (string $sniff, array $messages, array $warnings, array $errors, array 
 }
 // @phpcsProcessFixtureEnd
 
-// @phpcsSniff CodeQuality.DisallowShortOpenTag
+// @phpcsSniff Inpsyde.CodeQuality.DisallowShortOpenTag
 ?>
 <div>
     <?= strtolower($x) ?>

--- a/tests/fixtures/element-name-minimal-length.php
+++ b/tests/fixtures/element-name-minimal-length.php
@@ -1,5 +1,5 @@
 <?php
-// @phpcsSniff CodeQuality.ElementNameMinimalLength
+// @phpcsSniff Inpsyde.CodeQuality.ElementNameMinimalLength
 
 namespace {
 

--- a/tests/fixtures/encoding-comment.php
+++ b/tests/fixtures/encoding-comment.php
@@ -3,7 +3,7 @@
 namespace Inpsyde\CodingStandard\Tests\Fixtures;
 
 
-// @phpcsSniff CodeQuality.EncodingComment
+// @phpcsSniff Inpsyde.CodeQuality.EncodingComment
 
 // @phpcsWarningCodeOnNextLine EncodingComment
 // -*- coding: utf-8 -*-

--- a/tests/fixtures/encoding-comment.php
+++ b/tests/fixtures/encoding-comment.php
@@ -15,4 +15,3 @@ namespace Inpsyde\CodingStandard\Tests\Fixtures;
 
 <?php //-*- coding: utf-8 -*-
 // @phpcsWarningOnPreviousLine CodeQuality.EncodingComment
-?>

--- a/tests/fixtures/forbidden-public-property.php
+++ b/tests/fixtures/forbidden-public-property.php
@@ -1,5 +1,5 @@
 <?php
-// @phpcsSniff CodeQuality.ForbiddenPublicProperty
+// @phpcsSniff Inpsyde.CodeQuality.ForbiddenPublicProperty
 
 $foo = 'foo';
 

--- a/tests/fixtures/function-body-start.php
+++ b/tests/fixtures/function-body-start.php
@@ -1,5 +1,5 @@
 <?php
-// @phpcsSniff CodeQuality.FunctionBodyStart
+// @phpcsSniff Inpsyde.CodeQuality.FunctionBodyStart
 
 namespace FunctionBodyStartTest;
 

--- a/tests/fixtures/function-length-no-blank-lines.php
+++ b/tests/fixtures/function-length-no-blank-lines.php
@@ -1,5 +1,5 @@
 <?php
-// @phpcsSniff CodeQuality.FunctionLength
+// @phpcsSniff Inpsyde.CodeQuality.FunctionLength
 
 // @phpcsSniffPropertiesStart
 // $ignoreBlankLines = false;

--- a/tests/fixtures/function-length-no-comments.php
+++ b/tests/fixtures/function-length-no-comments.php
@@ -1,5 +1,5 @@
 <?php
-// @phpcsSniff CodeQuality.FunctionLength
+// @phpcsSniff Inpsyde.CodeQuality.FunctionLength
 
 // @phpcsSniffPropertiesStart
 // $ignoreComments = false;

--- a/tests/fixtures/function-length.php
+++ b/tests/fixtures/function-length.php
@@ -1,5 +1,5 @@
 <?php
-// @phpcsSniff CodeQuality.FunctionLength
+// @phpcsSniff Inpsyde.CodeQuality.FunctionLength
 
 // @phpcsErrorOnNextLine
 function test() {

--- a/tests/fixtures/hook-closure-return.php
+++ b/tests/fixtures/hook-closure-return.php
@@ -1,6 +1,6 @@
 <?php
 
-// @phpcsSniff CodeQuality.HookClosureReturn
+// @phpcsSniff Inpsyde.CodeQuality.HookClosureReturn
 
 add_action('foo', 'bar');
 

--- a/tests/fixtures/hook-priority.php
+++ b/tests/fixtures/hook-priority.php
@@ -2,7 +2,7 @@
 
 namespace Inpsyde\CodingStandard\Tests\Fixtures;
 
-// @phpcsSniff CodeQuality.HookPriority
+// @phpcsSniff Inpsyde.CodeQuality.HookPriority
 add_action('foo', 'bar');
 
 add_filter('foo', [ArrayObject::class, 'meh']);

--- a/tests/fixtures/line-length.php
+++ b/tests/fixtures/line-length.php
@@ -1,5 +1,5 @@
 <?php
-// @phpcsSniff CodeQuality.LineLength
+// @phpcsSniff Inpsyde.CodeQuality.LineLength
 
 ?>
     <!-- Warning two lines below: multiple attributes can go each in one line -->
@@ -117,4 +117,3 @@ function longComment() {
             </div>
         </div>
     </div>
-

--- a/tests/fixtures/nesting-level.php
+++ b/tests/fixtures/nesting-level.php
@@ -1,5 +1,5 @@
 <?php
-// @phpcsSniff CodeQuality.NestingLevel
+// @phpcsSniff Inpsyde.CodeQuality.NestingLevel
 
 // @phpcsErrorOnNextLine
 function a()

--- a/tests/fixtures/no-accessors.php
+++ b/tests/fixtures/no-accessors.php
@@ -1,6 +1,6 @@
 <?php
 
-// @phpcsSniff CodeQuality.NoAccessors
+// @phpcsSniff Inpsyde.CodeQuality.NoAccessors
 
 function getting() {
 

--- a/tests/fixtures/no-else.php
+++ b/tests/fixtures/no-else.php
@@ -1,6 +1,6 @@
 <?php
 
-// @phpcsSniff CodeQuality.NoElse
+// @phpcsSniff Inpsyde.CodeQuality.NoElse
 
 if ('x') {
 

--- a/tests/fixtures/no-root-namespace-functions-multi.php
+++ b/tests/fixtures/no-root-namespace-functions-multi.php
@@ -1,5 +1,5 @@
 <?php
-// @phpcsSniff CodeQuality.NoRootNamespaceFunctions
+// @phpcsSniff Inpsyde.CodeQuality.NoRootNamespaceFunctions
 
 namespace Foo {
 

--- a/tests/fixtures/no-root-namespace-functions-single.php
+++ b/tests/fixtures/no-root-namespace-functions-single.php
@@ -1,5 +1,5 @@
 <?php
-// @phpcsSniff CodeQuality.NoRootNamespaceFunctions
+// @phpcsSniff Inpsyde.CodeQuality.NoRootNamespaceFunctions
 
 class Foo
 {

--- a/tests/fixtures/no-top-level-define.php
+++ b/tests/fixtures/no-top-level-define.php
@@ -2,7 +2,7 @@
 
 namespace Inpsyde\CodingStandard\Tests\Fixtures;
 
-// @phpcsSniff CodeQuality.NoTopLevelDefine
+// @phpcsSniff Inpsyde.CodeQuality.NoTopLevelDefine
 
 if (!defined('X')) {
     define('X', 1);

--- a/tests/fixtures/property-per-class-limit.php
+++ b/tests/fixtures/property-per-class-limit.php
@@ -1,5 +1,5 @@
 <?php
-// @phpcsSniff CodeQuality.PropertyPerClassLimit
+// @phpcsSniff Inpsyde.CodeQuality.PropertyPerClassLimit
 
 class Reasonable {
 

--- a/tests/fixtures/return-type-declaration.php
+++ b/tests/fixtures/return-type-declaration.php
@@ -1,5 +1,5 @@
 <?php
-// @phpcsSniff CodeQuality.ReturnTypeDeclaration
+// @phpcsSniff Inpsyde.CodeQuality.ReturnTypeDeclaration
 
 use Psr\Container\ContainerInterface as PsrContainer;
 

--- a/tests/fixtures/static-closure.php
+++ b/tests/fixtures/static-closure.php
@@ -1,5 +1,5 @@
 <?php
-// @phpcsSniff CodeQuality.StaticClosure
+// @phpcsSniff Inpsyde.CodeQuality.StaticClosure
 
 /**
  * @return string

--- a/tests/fixtures/trailing-semicolon.php
+++ b/tests/fixtures/trailing-semicolon.php
@@ -1,0 +1,27 @@
+<?php
+// @phpcsSniff InpsydeTemplates.Formatting.TrailingSemicolon
+
+?>
+
+<?= 'Test content'; // @phpcsWarningOnThisLine ?>
+<?= 'Without trailing semicolon' ?>
+
+<?php
+
+$content = 'New content';
+if ($content) {
+    echo $content;
+}
+?>
+
+<?php if ($content) : ?>
+    <?= $content ?>
+<?php endif; // @phpcsWarningOnThisLine ?>
+
+<?php // @phpcsWarningOnNextLine ?>
+<div aria-label="<?php echo $content; ?>">
+<?php // @phpcsWarningOnNextLine ?>
+    <?= $content; ?>
+</div>
+
+<?php

--- a/tests/fixtures/trailing-semicolon.php
+++ b/tests/fixtures/trailing-semicolon.php
@@ -7,7 +7,6 @@
 <?= 'Without trailing semicolon' ?>
 
 <?php
-
 $content = 'New content';
 if ($content) {
     echo $content;

--- a/tests/fixtures/var-names-camel-case.php
+++ b/tests/fixtures/var-names-camel-case.php
@@ -1,5 +1,5 @@
 <?php
-// @phpcsSniff CodeQuality.VariablesName
+// @phpcsSniff Inpsyde.CodeQuality.VariablesName
 
 // @phpcsSniffPropertiesStart
 // $checkType = "camelCase";

--- a/tests/fixtures/var-names-no-local.php
+++ b/tests/fixtures/var-names-no-local.php
@@ -1,5 +1,5 @@
 <?php
-// @phpcsSniff CodeQuality.VariablesName
+// @phpcsSniff Inpsyde.CodeQuality.VariablesName
 
 // @phpcsSniffPropertiesStart
 // $checkType = 'snake_case';

--- a/tests/fixtures/var-names-no-props.php
+++ b/tests/fixtures/var-names-no-props.php
@@ -1,5 +1,5 @@
 <?php
-// @phpcsSniff CodeQuality.VariablesName
+// @phpcsSniff Inpsyde.CodeQuality.VariablesName
 
 // @phpcsSniffPropertiesStart
 // $ignoreProperties = "true";

--- a/tests/fixtures/var-names-snake-case.php
+++ b/tests/fixtures/var-names-snake-case.php
@@ -1,5 +1,5 @@
 <?php
-// @phpcsSniff CodeQuality.VariablesName
+// @phpcsSniff Inpsyde.CodeQuality.VariablesName
 
 // @phpcsSniffPropertiesStart
 // $checkType = 'snake_case';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature.


**What is the current behavior?** (You can also link to an open issue here)
There are no rules targeted to the PHP templates.


**What is the new behavior (if this is a feature change)?**

PHP templates have specific formatting rules. For some of our projects, we follow [Plates-suggested syntax ](https://platesphp.com/templates/syntax/). It includes using alternative syntax for control structures, short echo tags, and avoiding semicolons. Therefore, creating a set of rules targeted to PHP templates makes sense.

The current PR introduces the `InpsydeTemplates` ruleset that could be used conditionally (or not used :smile: ) in your projects:

```xml
<rule ref="InpsydeTemplates">
    <include-pattern>*/templates/*</include-pattern>
    <include-pattern>*/views/*</include-pattern>
</rule>
```

For now, only one rule is added to remove trailing semicolons before closing PHP tags. A very nice investigation and usage comparison of this rule can be found here: https://github.com/prettier/plugin-php/issues/609#issuecomment-423863793.

Sure, we can and should discuss the approach widely. Maybe we could decide to maintain such rules in a separate repository. But since we already have a test suite and documentation here, in my opinion, it will be no harm to add custom rules that could be enabled conditionally.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.


**Other information**:

Apart from the feature, there is a small deprecation (since PHPCS 3.8.0) fix here - https://github.com/inpsyde/php-coding-standards/blob/441f7ceca8d0df4ea6bfab9798630cd2031c3fe5/tests/cases/FixturesTest.php#L227-L231. It could be applied separately.
