### PR TITLE
Allow setUpBeforeClass method name

### DIFF
--- a/Inpsyde/Sniffs/CodeQuality/NoAccessorsSniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/NoAccessorsSniff.php
@@ -40,6 +40,7 @@ class NoAccessorsSniff implements Sniff
         'getInnerIterator',
         'getChildren',
         'setUp',
+        'setUpBeforeClass',
     ];
 
     public bool $skipForPrivate = true;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

In addition to the `setUp` method name, this PR allows the [`setUpBeforeClass`](https://github.com/sebastianbergmann/phpunit/blob/ef9f6359c9e4c939a8ee9f729c03b3de0c42d179/src/Framework/TestCase.php#L234) method name, used by PhpUnit (amongst others, maybe).

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



**Other information**:
