### PR TITLE
fix: InpsydeTemplates usage

### DIFF
--- a/InpsydeTemplates/ruleset.xml
+++ b/InpsydeTemplates/ruleset.xml
@@ -3,8 +3,6 @@
 
     <description>Coding standards for PHP templates.</description>
 
-    <rule ref="Inpsyde">
-        <exclude name="Inpsyde.CodeQuality.NoElse" />
-    </rule>
+    <rule ref="Inpsyde" />
 
 </ruleset>

--- a/README.md
+++ b/README.md
@@ -184,8 +184,7 @@ For **notes and configuration** see [`/inpsyde-custom-sniffs.md`](/inpsyde-custo
 
 ## Template Rules
 
-The `InpsydeTemplates` ruleset extends the standard `Inpsyde` ruleset with some template-specific
-sniffs while disabling some rules that are not useful in templating context.
+The `InpsydeTemplates` ruleset extends the standard `Inpsyde` ruleset with some template-specific sniffs.
 
 The recommended way to use the `InpsydeTemplates` ruleset is as follows:
 
@@ -196,10 +195,7 @@ The recommended way to use the `InpsydeTemplates` ruleset is as follows:
     <file>./templates</file>
     <file>./views</file>
 
-    <rule ref="Inpsyde">
-        <exclude-pattern>*/templates/*</exclude-pattern>
-        <exclude-pattern>*/views/*</exclude-pattern>
-    </rule>
+    <rule ref="Inpsyde" />
 
     <rule ref="InpsydeTemplates">
         <include-pattern>*/templates/*</include-pattern>
@@ -207,8 +203,6 @@ The recommended way to use the `InpsydeTemplates` ruleset is as follows:
     </rule>
 </ruleset>
 ```
-The following `Inpsyde` rules are disabled:
-* `NoElse`
 
 The following templates-specific rules are available:
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Documentation and logic fix.


**What is the current behavior?** (You can also link to an open issue here)
Documentation introduced in https://github.com/inpsyde/php-coding-standards/pull/81 PR leads to the broken behavior. Custom Inpsyde sniffs and sniffs imported in the Insyde ruleset are not applied to the `templates` directory if the package configuration file contains the following:
```xml
<rule ref="Inpsyde">
    <exclude-pattern>*/templates/*</exclude-pattern>
</rule>
```


**What is the new behavior (if this is a feature change)?**
I double-checked different options and asked for PHPCS maintainers' support (see https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/380), but apparently, PHPCS doesn't support what we need right now. I.e., `exclude-pattern` and `include-pattern` are applied globally (and `exclude` has priority).

It means disabling any of the `Inpsyde` rules from the `InpsydeTemplates` ruleset is impossible. So, we have to come back to the initial suggestion:
```xml
<rule ref="Inpsyde" />

<rule ref="InpsydeTemplates">
    <include-pattern>*/templates/*</include-pattern>
    <include-pattern>*/views/*</include-pattern>
</rule>
```
This way, the whole project will be checked with `Inpsyde` CS, and `templates` and `views` directories will also be checked with `InpsydeTemplates` CS. If someone needs to exclude `NoElse` or any rule, they should do it explicitly in the project configuration.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
It's rather a bug fix.


**Other information**:
