### PR TITLE
Update serialization mechanism

### DIFF
--- a/Inpsyde/Sniffs/CodeQuality/DisableMagicSerializeSniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/DisableMagicSerializeSniff.php
@@ -13,9 +13,7 @@ class DisableMagicSerializeSniff implements Sniff
 {
     /** @var list<string>  */
     public array $disabledFunctions = [
-        '__serialize',
         '__sleep',
-        '__unserialize',
         '__wakeup',
     ];
 
@@ -45,7 +43,7 @@ class DisableMagicSerializeSniff implements Sniff
         if (in_array($name, $this->disabledFunctions, true)) {
             $phpcsFile->addError(
                 sprintf(
-                    'The method "%s" is forbidden, please use Serializable interface.',
+                    'The method "%s" is deprecated, please use __serialize and __unserialize instead.',
                     $name
                 ),
                 $stackPtr,

--- a/Inpsyde/Sniffs/CodeQuality/DisableMagicSerializeSniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/DisableMagicSerializeSniff.php
@@ -11,10 +11,10 @@ use PHPCSUtils\Utils\Scopes;
 
 class DisableMagicSerializeSniff implements Sniff
 {
-    /** @var list<string>  */
+    /** @var array<string, string>  */
     public array $disabledFunctions = [
-        '__sleep',
-        '__wakeup',
+        '__sleep' => '__serialize',
+        '__wakeup' => '__unserialize',
     ];
 
     /**
@@ -40,13 +40,10 @@ class DisableMagicSerializeSniff implements Sniff
         }
 
         $name = FunctionDeclarations::getName($phpcsFile, $stackPtr);
-        if (in_array($name, $this->disabledFunctions, true)) {
+        $alternative = $this->disabledFunctions[$name] ?? null;
+        if ($alternative !== null) {
             $phpcsFile->addError(
-                sprintf(
-                    'The method "%s" is deprecated, '
-                    . 'please use __serialize and __unserialize instead.',
-                    $name
-                ),
+                "The method '{$name}' is deprecated, please use '{$alternative}' instead.",
                 $stackPtr,
                 'Found'
             );

--- a/Inpsyde/Sniffs/CodeQuality/DisableMagicSerializeSniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/DisableMagicSerializeSniff.php
@@ -43,7 +43,8 @@ class DisableMagicSerializeSniff implements Sniff
         if (in_array($name, $this->disabledFunctions, true)) {
             $phpcsFile->addError(
                 sprintf(
-                    'The method "%s" is deprecated, please use __serialize and __unserialize instead.',
+                    'The method "%s" is deprecated, '
+                    . 'please use __serialize and __unserialize instead.',
                     $name
                 ),
                 $stackPtr,

--- a/Inpsyde/Sniffs/CodeQuality/DisableSerializeInterfaceSniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/DisableSerializeInterfaceSniff.php
@@ -11,7 +11,7 @@ use PHPCSUtils\Utils\ObjectDeclarations;
 class DisableSerializeInterfaceSniff implements Sniff
 {
     /**
-     * @return list<int>
+     * @return list<int|string>
      */
     public function register(): array
     {
@@ -33,7 +33,7 @@ class DisableSerializeInterfaceSniff implements Sniff
     public function process(File $phpcsFile, $stackPtr): void
     {
         // phpcs:enable Inpsyde.CodeQuality.ArgumentTypeDeclaration
-        $tokenCode = $phpcsFile->getTokens()[$stackPtr]['code'];
+        $tokenCode = $phpcsFile->getTokens()[$stackPtr]['code'] ?? null;
         $find = ($tokenCode === \T_INTERFACE)
             ? ObjectDeclarations::findExtendedInterfaceNames($phpcsFile, $stackPtr)
             : ObjectDeclarations::findImplementedInterfaceNames($phpcsFile, $stackPtr);
@@ -43,7 +43,8 @@ class DisableSerializeInterfaceSniff implements Sniff
         }
 
         $phpcsFile->addError(
-            'The Serializable interface is deprecated, please use __serialize and __unserialize instead.',
+            'The Serializable interface is deprecated, '
+            . 'please use __serialize and __unserialize instead.',
             $stackPtr,
             'Found'
         );

--- a/Inpsyde/Sniffs/CodeQuality/DisableSerializeInterfaceSniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/DisableSerializeInterfaceSniff.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Inpsyde\Sniffs\CodeQuality;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHPCSUtils\Utils\ObjectDeclarations;
+
+class DisableSerializeInterfaceSniff implements Sniff
+{
+    /**
+     * @return list<int>
+     */
+    public function register(): array
+    {
+        return [
+            \T_CLASS,
+            \T_ANON_CLASS,
+            \T_ENUM,
+            \T_INTERFACE,
+        ];
+    }
+
+    /**
+     * @param File $phpcsFile
+     * @param int $stackPtr
+     * @return void
+     *
+     * phpcs:disable Inpsyde.CodeQuality.ArgumentTypeDeclaration
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        // phpcs:enable Inpsyde.CodeQuality.ArgumentTypeDeclaration
+        $tokenCode = $phpcsFile->getTokens()[$stackPtr]['code'];
+        $find = ($tokenCode === \T_INTERFACE)
+            ? ObjectDeclarations::findExtendedInterfaceNames($phpcsFile, $stackPtr)
+            : ObjectDeclarations::findImplementedInterfaceNames($phpcsFile, $stackPtr);
+
+        if (($find === false) || !in_array('Serializable', $find, true)) {
+            return;
+        }
+
+        $phpcsFile->addError(
+            'The Serializable interface is deprecated, please use __serialize and __unserialize instead.',
+            $stackPtr,
+            'Found'
+        );
+    }
+}

--- a/README.md
+++ b/README.md
@@ -117,30 +117,31 @@ Some rules are also included from PHP_CodeSniffer itself, as well as [PHPCSExtra
 
 The following custom rules are in use:
 
-| Sniff Name                 | Description                                                                                    | Has Config | Auto-Fixable |
-|:---------------------------|:-----------------------------------------------------------------------------------------------|:----------:|:------------:|
-| `ArgumentTypeDeclaration`  | Enforce argument type declaration.                                                             |            |              |
-| `DisableCallUserFunc`      | Disable usage of `call_user_func`.                                                             |            |              |
-| `DisableMagicSerialize`    | Disable usage of `__serialize`, `__sleep`, `__unserialize`, `__wakeup`.                        |            |              |
-| `DisallowShortOpenTag`     | Disallow short open PHP tag (short echo tag allowed).                                          |            |              |
-| `ElementNameMinimalLength` | Use minimum 3 chars for names (with a few exclusions)                                          |     ✓      |              |
-| `EncodingComment`          | Detect usage of opening `-*- coding: utf-8 -*-`                                                |     ✓      |      ✓       |
-| `ForbiddenPublicProperty`  | No public class properties                                                                     |            |              |
-| `FunctionBodyStart`        | Handle blank line at start of function body.                                                   |            |      ✓       |
-| `FunctionLength`           | Max 50 lines per function/method, excluding blank lines and comments-only lines.               |     ✓      |              |
-| `HookClosureReturn`        | Ensure that actions callbacks do not return anything, while filter callbacks return something. |            |              |
-| `HookPriority`             | Report usage of `PHP_INT_MAX` and `PHP_INT_MIN` as hook priority.                              |            |              |
-| `LineLength`               | Max 100 chars per line                                                                         |     ✓      |              |
-| `NestingLevel`             | Max indent level of 3 inside functions                                                         |     ✓      |              |
-| `NoAccessors`              | Discourage usage of getters and setters.                                                       |            |              |
-| `NoElse`                   | Discourage usage of `else`.                                                                    |            |              |
-| `NoRootNamespaceFunctions` | Report usage of global functions in the root namespace.                                        |            |              |
-| `NoTopLevelDefine`         | Discourage usage of `define` where `const` is preferable.                                      |            |              |
-| `PropertyPerClassLimit`    | Discourage usage of more than 10 properties per class.                                         |     ✓      |              |
-| `Psr4`                     | Check PSR-4 compliance                                                                         |     ✓      |              |
-| `ReturnTypeDeclaration`    | Enforce return type declaration                                                                |            |              |
-| `StaticClosure`            | Points closures that can be `static`.                                                          |            |      ✓       |
-| `VariablesName`            | Check variable (and properties) names                                                          |     ✓      |              |
+| Sniff Name                  | Description                                                                                    | Has Config | Auto-Fixable |
+|:----------------------------|:-----------------------------------------------------------------------------------------------|:----------:|:------------:|
+| `ArgumentTypeDeclaration`   | Enforce argument type declaration.                                                             |            |              |
+| `DisableCallUserFunc`       | Disable usage of `call_user_func`.                                                             |            |              |
+| `DisableMagicSerialize`     | Disable usage of `__sleep`, `__wakeup`.                                                        |            |              |
+| `DisableSerializeInterface` | Disable usage of `Serializable` interface.                                                     |            |              |
+| `DisallowShortOpenTag`      | Disallow short open PHP tag (short echo tag allowed).                                          |            |              |
+| `ElementNameMinimalLength`  | Use minimum 3 chars for names (with a few exclusions)                                          |     ✓      |              |
+| `EncodingComment`           | Detect usage of opening `-*- coding: utf-8 -*-`                                                |     ✓      |      ✓       |
+| `ForbiddenPublicProperty`   | No public class properties                                                                     |            |              |
+| `FunctionBodyStart`         | Handle blank line at start of function body.                                                   |            |      ✓       |
+| `FunctionLength`            | Max 50 lines per function/method, excluding blank lines and comments-only lines.               |     ✓      |              |
+| `HookClosureReturn`         | Ensure that actions callbacks do not return anything, while filter callbacks return something. |            |              |
+| `HookPriority`              | Report usage of `PHP_INT_MAX` and `PHP_INT_MIN` as hook priority.                              |            |              |
+| `LineLength`                | Max 100 chars per line                                                                         |     ✓      |              |
+| `NestingLevel`              | Max indent level of 3 inside functions                                                         |     ✓      |              |
+| `NoAccessors`               | Discourage usage of getters and setters.                                                       |            |              |
+| `NoElse`                    | Discourage usage of `else`.                                                                    |            |              |
+| `NoRootNamespaceFunctions`  | Report usage of global functions in the root namespace.                                        |            |              |
+| `NoTopLevelDefine`          | Discourage usage of `define` where `const` is preferable.                                      |            |              |
+| `PropertyPerClassLimit`     | Discourage usage of more than 10 properties per class.                                         |     ✓      |              |
+| `Psr4`                      | Check PSR-4 compliance                                                                         |     ✓      |              |
+| `ReturnTypeDeclaration`     | Enforce return type declaration                                                                |            |              |
+| `StaticClosure`             | Points closures that can be `static`.                                                          |            |      ✓       |
+| `VariablesName`             | Check variable (and properties) names                                                          |     ✓      |              |
 
 For **notes and configuration**, refer to the [`inpsyde-custom-sniffs.md`](/inpsyde-custom-sniffs.md)
 file in this repository.

--- a/tests/unit/fixtures/disallow-magic-serialize.php
+++ b/tests/unit/fixtures/disallow-magic-serialize.php
@@ -4,7 +4,6 @@
 
 class Foo {
 
-    // @phpcsErrorOnNextLine
     public function __serialize(): array
     {
         return [];
@@ -37,7 +36,6 @@ class Foo {
         return [];
     }
 
-    // @phpcsErrorOnNextLine
     public function __unserialize(): array
     {
         return [];

--- a/tests/unit/fixtures/disallow-serialize-interface.php
+++ b/tests/unit/fixtures/disallow-serialize-interface.php
@@ -1,0 +1,58 @@
+<?php
+
+// @phpcsSniff Inpsyde.CodeQuality.DisableSerializeInterface
+
+// @phpcsErrorOnNextLine
+class One implements Serializable {
+
+    public function serialize()
+    {
+        return null;
+    }
+
+    public function unserialize($data)
+    {
+    }
+}
+
+// @phpcsErrorOnNextLine
+$x = new class implements Serializable {
+
+    public function serialize()
+    {
+        return null;
+    }
+
+    public function unserialize($data)
+    {
+    }
+};
+
+class Three {
+
+    public function serialize()
+    {
+        return null;
+    }
+
+    public function unserialize($data)
+    {
+    }
+}
+
+// @phpcsErrorOnNextLine
+interface Two extends Serializable {
+
+}
+
+class Four {
+
+    public function __serialize()
+    {
+        return null;
+    }
+
+    public function __unserialize($data)
+    {
+    }
+}


### PR DESCRIPTION
Currently we have [a rule that discourages the usage of magic `__serialize` and `__unserialize`](https://github.com/inpsyde/php-coding-standards/blob/version/2/Inpsyde/Sniffs/CodeQuality/DisableMagicSerializeSniff.php#L16-L18) while suggesting usage of the `Serializable` interface.

That was the "state of the art" up to PHP 7.3, and the rule even predates that.

With PHP 7.4 the `Serializable` interface is [not recommended anymore](https://wiki.php.net/rfc/custom_object_serialization) (the RFC define it as _"severely broken"_).

The new recommended method is to use `__serialize` and `__unserialize` methods.

Not being a major release PHP 7.4 did not deprecate `Serializable`.

PHP 8.1 [triggers a deprecation warning](ttps://www.php.net/manual/en/class.serializable.php) if `Serializable` without _also_ having `__serialize` and `__unserialize`.

And PHP 9 will probably remove the interface altogether.

Because v2 is PHP 7.4 we can safely discourage `Serializable` already and fully recommend `__serialize` and `__unserialize`.

This PR does that by:

- Edit the sniff that discouraged `__serialize` and `__unserialize` to actually suggest them where `__sleep` and `__wakeup` are used
- Add a sniff to discourage `Serializable` interface, suggesting `__serialize` and `__unserialize` 

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature.


**What is the current behavior?** (You can also link to an open issue here)

- `__serialize` and `__unserialize` are discouraged
- `Serializable` interface is suggested

**What is the new behavior (if this is a feature change)?**

- `__serialize` and `__unserialize` are suggested
- `Serializable` interface is discouraged

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

- New errors might be reported

**Other information**:

--
