### PR TITLE
Force zero spaces after Not operator

### DIFF
--- a/Inpsyde/ruleset.xml
+++ b/Inpsyde/ruleset.xml
@@ -149,7 +149,7 @@
     <rule ref="Generic.Formatting.SpaceAfterCast"/>
     <rule ref="Generic.Formatting.SpaceAfterNot">
         <properties>
-            <property name="spacing" value="0" />
+            <property name="spacing" value="0"/>
         </properties>
     </rule>
     <rule ref="Generic.Metrics.CyclomaticComplexity">

--- a/Inpsyde/ruleset.xml
+++ b/Inpsyde/ruleset.xml
@@ -147,6 +147,11 @@
     <rule ref="Generic.CodeAnalysis.AssignmentInCondition"/>
     <rule ref="Generic.CodeAnalysis.EmptyPHPStatement"/>
     <rule ref="Generic.Formatting.SpaceAfterCast"/>
+    <rule ref="Generic.Formatting.SpaceAfterNot">
+        <properties>
+            <property name="spacing" value="0" />
+        </properties>
+    </rule>
     <rule ref="Generic.Metrics.CyclomaticComplexity">
         <properties>
             <property name="absoluteComplexity" value="50"/>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?**
New rule is added to the ruleset.


**What is the current behavior?**
Both `!$variable` and `! $variable` pass the check.


**What is the new behavior?**
Only `!$variable` pass the check.


**Does this PR introduce a breaking change?**
No.


**Other information**:
I used the rule from PHP_CodeSniffer itself and not the one from Slevomat as suggested in the issue. I realized that the one from Slevomat was actually checking for `-` instead of `!`, and anyway there was no reason for not using this existing one.