### PR TITLE
Fix RiskyTruthyFalsyComparison

### DIFF
--- a/Inpsyde/Helpers/FunctionDocBlock.php
+++ b/Inpsyde/Helpers/FunctionDocBlock.php
@@ -101,7 +101,7 @@ final class FunctionDocBlock
     {
         $tagName = '@' . ltrim($tag, '@');
         $tags = static::allTags($file, $position);
-        if (empty($tags[$tagName])) {
+        if (!isset($tags[$tagName]) || $tags[$tagName] === []) {
             return [];
         }
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -27,5 +27,8 @@
         <MixedAssignment errorLevel="suppress" />
         <RedundantCastGivenDocblockType errorLevel="suppress" />
         <RedundantConditionGivenDocblockType errorLevel="suppress" />
+
+        <!-- Suppressing that can be removed when minimum PHP version will become 8.3 -->
+        <MissingClassConstType errorLevel="suppress" />
     </issueHandlers>
 </psalm>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?**
Fixes PSALM alert `RiskyTruthyFalsyComparison`.

**Other information:**
FILE: _Inpsyde/Helpers/FunctionDocBlock.php_

`Operand of type list<string>|null contains type list<string>, which can be falsy and truthy. This can cause possibly unexpected behavior. Use strict comparison instead.`