### PR TITLE
Add Sniffs for Array Spacing and Property Types

### DIFF
--- a/Inpsyde/Sniffs/CodeQuality/Psr4Sniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/Psr4Sniff.php
@@ -11,7 +11,9 @@ use PHPCSUtils\Utils\ObjectDeclarations;
 
 class Psr4Sniff implements Sniff
 {
+    /** @var array<string, string> */
     public array $psr4 = [];
+    /** @var list<string> */
     public array $exclude = [];
 
     /**
@@ -112,10 +114,6 @@ class Psr4Sniff implements Sniff
         $filePath = str_replace('\\', '/', $file->getFilename());
 
         foreach ($this->psr4 as $baseNamespace => $foldersStr) {
-            if (!is_string($baseNamespace) || !is_string($foldersStr)) {
-                continue;
-            }
-
             $baseNamespace = trim($baseNamespace, '\\');
             if (strpos($namespace, $baseNamespace) !== 0) {
                 continue;

--- a/Inpsyde/Sniffs/CodeQuality/VariablesNameSniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/VariablesNameSniff.php
@@ -48,6 +48,7 @@ class VariablesNameSniff implements Sniff
     ];
 
     public string $checkType = 'camelCase';
+    /** @var list<string> */
     public array $ignoredNames = [];
     public bool $ignoreLocalVars = false;
     public bool $ignoreProperties = false;

--- a/Inpsyde/ruleset.xml
+++ b/Inpsyde/ruleset.xml
@@ -120,6 +120,9 @@
     Slevomat
     See https://github.com/slevomat/coding-standard
     -->
+    <rule ref="SlevomatCodingStandard.Arrays.SingleLineArrayWhitespace">
+        <type>warning</type>
+    </rule>
     <rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration">
         <type>warning</type>
         <properties>
@@ -131,6 +134,7 @@
             <property name="spacesCountAroundEqualsSign" type="integer" value="0"/>
         </properties>
     </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint" />
     <rule ref="SlevomatCodingStandard.Whitespaces.DuplicateSpaces">
         <type>warning</type>
         <properties>
@@ -169,6 +173,9 @@
     </rule>
     <rule ref="Generic.WhiteSpace.LanguageConstructSpacing"/>
     <rule ref="Generic.WhiteSpace.SpreadOperatorSpacingAfter"/>
+    <rule ref="Squiz.Arrays.ArrayBracketSpacing">
+        <type>warning</type>
+    </rule>
     <rule ref="Squiz.Classes.LowercaseClassKeywords"/>
     <rule ref="Squiz.PHP.CommentedOutCode">
         <properties>

--- a/tests/src/SniffMessages.php
+++ b/tests/src/SniffMessages.php
@@ -6,8 +6,11 @@ namespace Inpsyde\CodingStandard\Tests;
 
 final class SniffMessages
 {
+    /** @var array<int, string> */
     private array $warnings;
+    /** @var array<int, string> */
     private array $errors;
+    /** @var array<int, string> */
     private array $messages;
     private bool $messagesContainTotal = false;
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR adds three new Sniffs to the `Inpsyde` standard:
- `SlevomatCodingStandard.Arrays.SingleLineArrayWhitespace`
- `SlevomatCodingStandard.TypeHints.PropertyTypeHint`
- `Squiz.Arrays.ArrayBracketSpacing`

**What is the current behavior?** (You can also link to an open issue here)

- Array access and single-line declaration can have arbitrary spacing around square brackets.
- Properties can have no type information at all.

**What is the new behavior (if this is a feature change)?**

- Consistent array access and single-line declaration without undesired whitespace.
- Well-documented property types, wherever possible.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No, but existing code that violates the new rules will get flagged, of course.

**Other information**:

This PR closes issues #78 and #91.