### PR TITLE
Fix bug in StaticClosure sniff

### DIFF
--- a/Inpsyde/Sniffs/CodeQuality/StaticClosureSniff.php
+++ b/Inpsyde/Sniffs/CodeQuality/StaticClosureSniff.php
@@ -90,7 +90,7 @@ class StaticClosureSniff implements Sniff
         $fixer = $file->fixer;
         $fixer->beginChangeset();
 
-        $fixer->replaceToken($position, 'static function');
+        $fixer->addContentBefore($position, 'static ');
 
         $fixer->endChangeset();
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR fixes a bug with a non-static `fn` arrow function using implicit return, `fn () => 'foo'`, that could be static.

**What is the current behavior?** (You can also link to an open issue here)

Given this code:

```php
fn () => 'foo'
```

`phpcs` will correctly report the closure being non-static, while it could. However, running `phpcbf` will result in the following invalid code:

```php
static function () => 'foo'
```

Notice the implicit return that is invalid for a proper function.

**What is the new behavior (if this is a feature change)?**

With the PR merged, the fixed code will look like so:

```php
static fn () => 'foo'
```

The closure is still an arrow function, making use of implicit return, but now `static`.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

**Other information**:
