### PR TITLE
Lint PHP 8.4

### DIFF
--- a/.github/workflows/quality-assurance-php.yml
+++ b/.github/workflows/quality-assurance-php.yml
@@ -44,7 +44,7 @@ jobs:
         uses: inpsyde/reusable-workflows/.github/workflows/lint-php.yml@main
         strategy:
             matrix:
-                php-ver: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
+                php-ver: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
         with:
             PHP_VERSION: ${{ matrix.php-ver }}
             LINT_ARGS: '-e php --colors --show-deprecated ./Inpsyde'


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Lint the codebase on PHP 8.4 too.

**What is the current behavior?** (You can also link to an open issue here)

Linting is done on PHP 7.4-8.3.

**What is the new behavior (if this is a feature change)?**

Linting is done on PHP 8.4 too.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

**Other information**:

Currently, there is no stable version of Psalm that supports PHP 8.4, so we cannot run Psalm. Sadly, having Psalm declared as Composer dependency, we also cannot run PHPUnit because the `composer install` fails due to Psalm...