### PR TITLE
Maintenance Mode and syde/phpcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 ---
 
 > [!IMPORTANT]
-> Development on this package has shifted to maintenance mode. We remain committed to fixing bugs, ensuring compatibility, and addressing security concerns, but new features are not planned at this time. For active projects, we recommend migrating to [`syde/phpcs`](https://github.com/inpsyde/phpcs), the next-generation Syde PHP Coding Standards, supporting PHP 8.1+.
+> Please note that development on **this package has shifted to maintenance mode** only. We remain committed to fixing bugs, ensuring compatibility, and addressing security concerns **until July 31, 2025**. New features are not planned at this time. Maintenance mode will end on August 1, 2025, effectively marking the End-of-Life date of this package.
+> 
+> For active projects, we **strongly recommend migrating to [`syde/phpcs`](https://github.com/inpsyde/phpcs)**, the next-generation Syde PHP Coding Standards for WordPress development at scale, supporting PHP 8.1+. Please refer to the dedicated [Migration](https://github.com/inpsyde/phpcs/blob/main/docs/Migration.md) docs to get a high-level understanding of the potential migration effort.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 
 ---
 
+> [!IMPORTANT]
+> Development on this package has shifted to maintenance mode. We remain committed to fixing bugs, ensuring compatibility, and addressing security concerns, but new features are not planned at this time. For active projects, we recommend migrating to [`syde/phpcs`](https://github.com/inpsyde/phpcs), the next-generation Syde PHP Coding Standards, supporting PHP 8.1+.
+
+---
+
 # Usage
 
 When the package is installed via Composer, and dependencies are updated, everything is ready and 

--- a/composer.json
+++ b/composer.json
@@ -80,5 +80,8 @@
             "composer/*": true,
             "dealerdirect/phpcodesniffer-composer-installer": true
         }
+    },
+    "suggest": {
+        "syde/phpcs": "The next-generation Syde PHP Coding Standards for WordPress development at scale, supporting PHP 8.1+."
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Inform users about shifting to maintenance mode, and the new [`syde/phpcs`](https://github.com/inpsyde/phpcs) package.

**What is the current behavior?** (You can also link to an open issue here)

Users do not know about maintenance mode, nor `syde/phpcs`.

**What is the new behavior (if this is a feature change)?**

The README informs about the package being in maintenance mode, and recommends migrating to the new `syde/phpcs` package. Composer will suggest using the package, too.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



**Other information**:
