### PR TITLE
Fix deprecation notice in Inpsyde ruleset.xml

### DIFF
--- a/Inpsyde/ruleset.xml
+++ b/Inpsyde/ruleset.xml
@@ -27,7 +27,9 @@
     <rule ref="WordPress.DateTime.CurrentTimeTimestamp"/>
     <rule ref="WordPress.DateTime.RestrictedFunctions">
         <properties>
-            <property name="exclude" type="array" value="date"/>
+            <property name="exclude" type="array">
+                <element key="0" value="date" />
+            </property>
         </properties>
     </rule>
     <rule ref="WordPress.NamingConventions.PrefixAllGlobals"/>
@@ -47,7 +49,11 @@
     <rule ref="WordPress.PHP.RestrictedPHPFunctions"/>
     <rule ref="WordPress.PHP.DiscouragedPHPFunctions">
         <properties>
-            <property name="exclude" type="array" value="serialize,urlencode,obfuscation"/>
+            <property name="exclude" type="array">
+                <element key="0" value="serialize" />
+                <element key="1" value="urlencode" />
+                <element key="2" value="obfuscation" />
+            </property>
         </properties>
     </rule>
     <rule ref="WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration">


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)

Inpsyde ruleset.xml used a comma-separated string for array configurations, which is deprecated since PHPCS 3.3 and will break in PHPCS 4.0. See [release notes](https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.3.0#:~:text=Setting%20Array%20Properties)


**What is the new behavior (if this is a feature change)?**
The new syntax `<property ... type="array"><element key="..." value="..."></property>` is used.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

**Other information**:
